### PR TITLE
feat: support nest 10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nestjs-plugins/nestjs-nats-streaming-transport",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nestjs-plugins/nestjs-nats-streaming-transport",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "ISC",
       "dependencies": {
         "node-nats-streaming": "^0.3.2",
@@ -15,44 +15,49 @@
         "shortid": "^2.2.16"
       },
       "devDependencies": {
-        "@nestjs/common": "^9.2.0",
-        "@nestjs/core": "^9.2.0",
-        "@nestjs/microservices": "^9.2.0",
+        "@nestjs/common": "^10.0.0",
+        "@nestjs/core": "^10.0.0",
+        "@nestjs/microservices": "^10.0.0",
         "@types/node": "^18.11.9",
         "rimraf": "^3.0.2",
         "typescript": "^4.8.4"
       },
       "peerDependencies": {
-        "@nestjs/common": "^9.2.0",
-        "@nestjs/core": "^9.2.0",
-        "@nestjs/microservices": "^9.2.0"
+        "@nestjs/common": "^10.0.0",
+        "@nestjs/core": "^10.0.0",
+        "@nestjs/microservices": "^10.0.0"
+      }
+    },
+    "node_modules/@lukeed/csprng": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.1.0.tgz",
+      "integrity": "sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@nestjs/common": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-9.2.0.tgz",
-      "integrity": "sha512-Ndcqak/ETYi+n1c5lFRPbxKLyUuM6DIOxcvfEFGfi0f6ad4dWDXRDx7z/n8V0l8+Y8djvvOHgf3t0e93w963Qg==",
+      "version": "10.2.7",
+      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-10.2.7.tgz",
+      "integrity": "sha512-cUtCRXiUstDmh4bSBhVbq4cI439Gngp4LgLGLBmd5dqFQodfXKnSD441ldYfFiLz4rbUsnoMJz/8ZjuIEI+B7A==",
       "dev": true,
       "dependencies": {
         "iterare": "1.2.1",
-        "tslib": "2.4.1",
-        "uuid": "9.0.0"
+        "tslib": "2.6.2",
+        "uid": "2.0.2"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/nest"
       },
       "peerDependencies": {
-        "cache-manager": "<=5",
         "class-transformer": "*",
         "class-validator": "*",
         "reflect-metadata": "^0.1.12",
         "rxjs": "^7.1.0"
       },
       "peerDependenciesMeta": {
-        "cache-manager": {
-          "optional": true
-        },
         "class-transformer": {
           "optional": true
         },
@@ -62,29 +67,28 @@
       }
     },
     "node_modules/@nestjs/core": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-9.2.0.tgz",
-      "integrity": "sha512-eVN7aXAavV+ImVt8mO+rQ5YyUP6lJtQKUtQHxHKzz6Wg+9Y67WWZS2uDcDX5NNcNijbWky5bqad86fgcK9Oqig==",
+      "version": "10.2.7",
+      "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-10.2.7.tgz",
+      "integrity": "sha512-5GSu53QUUcwX17sNmlJPa1I0wIeAZOKbedyVuQx0ZAwWVa9g0wJBbsNP+R4EJ+j5Dkdzt/8xkiZvnKt8RFRR8g==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "@nuxtjs/opencollective": "0.3.2",
         "fast-safe-stringify": "2.1.1",
         "iterare": "1.2.1",
-        "object-hash": "3.0.0",
         "path-to-regexp": "3.2.0",
-        "tslib": "2.4.1",
-        "uuid": "9.0.0"
+        "tslib": "2.6.2",
+        "uid": "2.0.2"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/nest"
       },
       "peerDependencies": {
-        "@nestjs/common": "^9.0.0",
-        "@nestjs/microservices": "^9.0.0",
-        "@nestjs/platform-express": "^9.0.0",
-        "@nestjs/websockets": "^9.0.0",
+        "@nestjs/common": "^10.0.0",
+        "@nestjs/microservices": "^10.0.0",
+        "@nestjs/platform-express": "^10.0.0",
+        "@nestjs/websockets": "^10.0.0",
         "reflect-metadata": "^0.1.12",
         "rxjs": "^7.1.0"
       },
@@ -101,13 +105,13 @@
       }
     },
     "node_modules/@nestjs/microservices": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/@nestjs/microservices/-/microservices-9.2.0.tgz",
-      "integrity": "sha512-FyBalLu/B9gXPLs44s54O/GNLe3slrIwNTzP1BcBxRapbkrvtI0LWPKMC6sCTLfQyERc1g0+/YT+K+Ddg95YdQ==",
+      "version": "10.2.7",
+      "resolved": "https://registry.npmjs.org/@nestjs/microservices/-/microservices-10.2.7.tgz",
+      "integrity": "sha512-ggpng1yRuugPufn+OKeHV6Dcw3TWI7lmOvXkyYRwatVHQMvb3MlPpbzsA5PfUlg5DsjPGEWRbkIWN7OFb8OTyw==",
       "dev": true,
       "dependencies": {
         "iterare": "1.2.1",
-        "tslib": "2.4.1"
+        "tslib": "2.6.2"
       },
       "funding": {
         "type": "opencollective",
@@ -115,9 +119,9 @@
       },
       "peerDependencies": {
         "@grpc/grpc-js": "*",
-        "@nestjs/common": "^9.0.0",
-        "@nestjs/core": "^9.0.0",
-        "@nestjs/websockets": "^9.0.0",
+        "@nestjs/common": "^10.0.0",
+        "@nestjs/core": "^10.0.0",
+        "@nestjs/websockets": "^10.0.0",
         "amqp-connection-manager": "*",
         "amqplib": "*",
         "cache-manager": "*",
@@ -410,15 +414,6 @@
         "node": ">= 8.16.0"
       }
     },
-    "node_modules/object-hash": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
-      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
-      "dev": true,
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -506,9 +501,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/tweetnacl": {
       "version": "1.0.3",
@@ -528,13 +523,16 @@
         "node": ">=4.2.0"
       }
     },
-    "node_modules/uuid": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
+    "node_modules/uid": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/uid/-/uid-2.0.2.tgz",
+      "integrity": "sha512-u3xV3X7uzvi5b1MncmZo3i2Aw222Zk1keqLA1YkHldREkAhAqi65wuPfe7lHx8H/Wzy+8CE7S7uS3jekIM5s8g==",
       "dev": true,
-      "bin": {
-        "uuid": "dist/bin/uuid"
+      "dependencies": {
+        "@lukeed/csprng": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/webidl-conversions": {
@@ -561,40 +559,45 @@
     }
   },
   "dependencies": {
+    "@lukeed/csprng": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.1.0.tgz",
+      "integrity": "sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==",
+      "dev": true
+    },
     "@nestjs/common": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-9.2.0.tgz",
-      "integrity": "sha512-Ndcqak/ETYi+n1c5lFRPbxKLyUuM6DIOxcvfEFGfi0f6ad4dWDXRDx7z/n8V0l8+Y8djvvOHgf3t0e93w963Qg==",
+      "version": "10.2.7",
+      "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-10.2.7.tgz",
+      "integrity": "sha512-cUtCRXiUstDmh4bSBhVbq4cI439Gngp4LgLGLBmd5dqFQodfXKnSD441ldYfFiLz4rbUsnoMJz/8ZjuIEI+B7A==",
       "dev": true,
       "requires": {
         "iterare": "1.2.1",
-        "tslib": "2.4.1",
-        "uuid": "9.0.0"
+        "tslib": "2.6.2",
+        "uid": "2.0.2"
       }
     },
     "@nestjs/core": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-9.2.0.tgz",
-      "integrity": "sha512-eVN7aXAavV+ImVt8mO+rQ5YyUP6lJtQKUtQHxHKzz6Wg+9Y67WWZS2uDcDX5NNcNijbWky5bqad86fgcK9Oqig==",
+      "version": "10.2.7",
+      "resolved": "https://registry.npmjs.org/@nestjs/core/-/core-10.2.7.tgz",
+      "integrity": "sha512-5GSu53QUUcwX17sNmlJPa1I0wIeAZOKbedyVuQx0ZAwWVa9g0wJBbsNP+R4EJ+j5Dkdzt/8xkiZvnKt8RFRR8g==",
       "dev": true,
       "requires": {
         "@nuxtjs/opencollective": "0.3.2",
         "fast-safe-stringify": "2.1.1",
         "iterare": "1.2.1",
-        "object-hash": "3.0.0",
         "path-to-regexp": "3.2.0",
-        "tslib": "2.4.1",
-        "uuid": "9.0.0"
+        "tslib": "2.6.2",
+        "uid": "2.0.2"
       }
     },
     "@nestjs/microservices": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/@nestjs/microservices/-/microservices-9.2.0.tgz",
-      "integrity": "sha512-FyBalLu/B9gXPLs44s54O/GNLe3slrIwNTzP1BcBxRapbkrvtI0LWPKMC6sCTLfQyERc1g0+/YT+K+Ddg95YdQ==",
+      "version": "10.2.7",
+      "resolved": "https://registry.npmjs.org/@nestjs/microservices/-/microservices-10.2.7.tgz",
+      "integrity": "sha512-ggpng1yRuugPufn+OKeHV6Dcw3TWI7lmOvXkyYRwatVHQMvb3MlPpbzsA5PfUlg5DsjPGEWRbkIWN7OFb8OTyw==",
       "dev": true,
       "requires": {
         "iterare": "1.2.1",
-        "tslib": "2.4.1"
+        "tslib": "2.6.2"
       }
     },
     "@nuxtjs/opencollective": {
@@ -782,12 +785,6 @@
       "resolved": "https://registry.npmjs.org/nuid/-/nuid-1.1.6.tgz",
       "integrity": "sha512-Eb3CPCupYscP1/S1FQcO5nxtu6l/F3k0MQ69h7f5osnsemVk5pkc8/5AyalVT+NCfra9M71U8POqF6EZa6IHvg=="
     },
-    "object-hash": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
-      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
-      "dev": true
-    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -863,9 +860,9 @@
       }
     },
     "tslib": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA=="
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "tweetnacl": {
       "version": "1.0.3",
@@ -878,11 +875,14 @@
       "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
       "dev": true
     },
-    "uuid": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
-      "dev": true
+    "uid": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/uid/-/uid-2.0.2.tgz",
+      "integrity": "sha512-u3xV3X7uzvi5b1MncmZo3i2Aw222Zk1keqLA1YkHldREkAhAqi65wuPfe7lHx8H/Wzy+8CE7S7uS3jekIM5s8g==",
+      "dev": true,
+      "requires": {
+        "@lukeed/csprng": "^1.0.0"
+      }
     },
     "webidl-conversions": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestjs-plugins/nestjs-nats-streaming-transport",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Nats Streaming Transport for NestJS",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -31,14 +31,14 @@
     "shortid": "^2.2.16"
   },
   "peerDependencies": {
-    "@nestjs/common": "^9.2.0",
-    "@nestjs/core": "^9.2.0",
-    "@nestjs/microservices": "^9.2.0"
+    "@nestjs/common": "^10.0.0",
+    "@nestjs/core": "^10.0.0",
+    "@nestjs/microservices": "^10.0.0"
   },
   "devDependencies": {
-    "@nestjs/common": "^9.2.0",
-    "@nestjs/core": "^9.2.0",
-    "@nestjs/microservices": "^9.2.0",
+    "@nestjs/common": "^10.0.0",
+    "@nestjs/core": "^10.0.0",
+    "@nestjs/microservices": "^10.0.0",
     "@types/node": "^18.11.9",
     "rimraf": "^3.0.2",
     "typescript": "^4.8.4"


### PR DESCRIPTION
This PR fixes the inability to  to use `@nestjs-plugins/nestjs-nats-streaming-transport: 1.2.0` with NestJS v10. 